### PR TITLE
Add comments to string and template nextgroup

### DIFF
--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -136,8 +136,8 @@ syntax region  javascriptTemplateSubstitution  contained matchgroup=javascriptTe
 syntax region  javascriptTemplateSBlock        contained start=/{/ end=/}/ contains=javascriptTemplateSBlock,javascriptTemplateSString transparent
 syntax region  javascriptTemplateSString       contained start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ extend contains=javascriptTemplateSStringRB transparent
 syntax match   javascriptTemplateSStringRB     /}/ contained 
-syntax region  javascriptString                start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ nextgroup=@javascriptSymbols skipwhite skipempty
-syntax region  javascriptTemplate              start=/`/  skip=/\\\\\|\\`\|\n/  end=/`\|$/ contains=javascriptTemplateSubstitution nextgroup=@javascriptSymbols skipwhite skipempty
+syntax region  javascriptString                start=/\z(["']\)/  skip=/\\\\\|\\\z1\|\\\n/  end=/\z1\|$/ nextgroup=@javascriptSymbols,@javascriptComments skipwhite skipempty
+syntax region  javascriptTemplate              start=/`/  skip=/\\\\\|\\`\|\n/  end=/`\|$/ contains=javascriptTemplateSubstitution nextgroup=@javascriptSymbols,@javascriptComments skipwhite skipempty
 " syntax match   javascriptTemplateTag           /\k\+/ nextgroup=javascriptTemplate
 syntax region  javascriptArray                 matchgroup=javascriptBraces start=/\[/ end=/]/ contains=@javascriptValue,javascriptForComprehension,@javascriptComments nextgroup=@javascriptSymbols,@javascriptComments skipwhite skipempty
 


### PR DESCRIPTION
I believe comments directly after strings and templates are highlighting incorrectly. A simple repro case is to include or omit a semicolon after a string:

![2](https://cloud.githubusercontent.com/assets/4745083/14964318/7afe6b44-105c-11e6-8e68-025d0ddddf60.png)
![3](https://cloud.githubusercontent.com/assets/4745083/14964339/91584d10-105c-11e6-9805-6368a69f97f9.png)

Without the semicolon, the incorrectly highlighted comment is using the `@javascriptSymbols` color rather than the `@javascriptComments` color.

Adding `@javascriptComments` to `nextgroup` (like [javascriptArray](https://github.com/sheerun/yajs.vim/blob/master/syntax/javascript.vim#L142)) fixes this:

![1](https://cloud.githubusercontent.com/assets/4745083/14964454/06bb9440-105d-11e6-8e6a-b8fd18e02fae.png)
